### PR TITLE
Catch zero variance features

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-# numba currently only supports Python up to 3.10
 python_requires = >=3.9
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.

--- a/src/corals/correlation/topk/_deprecated/original.py
+++ b/src/corals/correlation/topk/_deprecated/original.py
@@ -212,7 +212,41 @@ def topk_balltree_combined_tree_parallel_optimized(
         n_jobs_transfer_mode="function",  
         symmetrize=False, 
         argtopk_method="argsort",
-        require_sorted_topk=True):
+        require_sorted_topk=True,
+        handle_zero_variance="raise" # None, "raise", "return indices", 
+    ):
+    
+    if handle_zero_variance is not None:
+        
+        X = np.array(X)
+
+        X_zero_var_msk = np.all(np.isclose(X, X[0,:]), axis=0)
+        X_zero_var_idx = np.arange(X.shape[1])[X_zero_var_msk]
+
+        if handle_zero_variance == "raise":
+            if len(X_zero_var_idx) > 0:
+                raise ValueError(
+                    f"Zero variance in X. Please remove. Indices: {X_zero_var_idx}")
+            
+        if Y is not None:
+
+            Y = np.array(Y)
+
+            Y_zero_var_msk = np.all(np.isclose(Y, Y[0,:]), axis=0)
+            Y_zero_var_idx = np.arange(Y.shape[1])[Y_zero_var_msk]
+
+            if handle_zero_variance == "raise":
+                if len(Y_zero_var_idx) > 0:
+                    raise ValueError(
+                        f"Zero variance in Y. Please remove. Indices: {Y_zero_var_idx}")
+
+        if handle_zero_variance == "return indices":
+
+            if Y is None:
+                return None, X_zero_var_idx
+            else:
+                return None, (X_zero_var_idx, Y_zero_var_idx)
+
 
     if n_jobs is None:
         n_jobs = 1

--- a/tests/test_issue1.py
+++ b/tests/test_issue1.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+def test_issue1():
+
+    data = """
+Name	ERR4165185	ERR4165186	ERR4165187	ERR4165188	ERR4165189	ERR4165190	ERR4165191	ERR4165192	ERR4165193	ERR4165194
+Scp1_US851008_k31_TRINITY_DN18756_c0_g1_i4	0	0	0	0	0	0	0	0	0	0
+Scp1_US851008_k25_TRINITY_DN10094_c0_g1_i2	0	5.94091	5.58655	5.81978	5.39608	8.5646	6.63334	6.29947	4.76114	2.87519
+Scp1_US851008_k25_TRINITY_DN7610_c1_g1_i24	0	0.584322	0.361902	0.372344	0.372583	0	0.16313	0	0.874301	0.567489
+Scp1_US851008_k25_TRINITY_DN3138_c0_g1_i2	0	3.66967	2.61626	4.58642	1.00118	7.74655	6.50818	3.50205	2.80706	3.18808
+Scp1_US851008_k25_TRINITY_DN66949_c0_g1_i1	0	0.55958	0.508452	0.188733	0	2.05569	0.622747	0.18403	1.22889	0.525269
+Scp1_US851008_k25_TRINITY_DN42729_c0_g1_i3	0	NaN	0	0	0	0	0	0	4.98475	0
+Scp1_US851008_k25_TRINITY_DN5537_c0_g1_i1	0	0	0	0	0.068946	0.997404	0.394103	0.13994	0.375641	3.50364
+Scp1_US851008_k31_TRINITY_DN9195_c0_g2_i2	0	1.38316	0.785248	2.0806	1.17822	0	0	0	1.1218	5.1715
+Scp1_US851008_k31_TRINITY_DN9068_c0_g1_i22	0	0	0	0	0	0	0.164973	0.296276	0	2.88606
+"""
+    
+    from corals.threads import set_threads_for_external_libraries
+    set_threads_for_external_libraries(n_threads=1)
+
+    import pandas as pd
+    from io import StringIO
+    from corals.correlation.topk.default import cor_topk
+
+    df = pd.read_csv(StringIO(data), sep='\t')
+    df.set_index('Name', inplace=True)
+    df_transposed = df.T
+
+    with pytest.raises(ValueError) as e:
+        cor_topk(df_transposed, k=0.001, correlation_type="spearman", n_jobs=4)
+    assert e.match(r"^Zero variance in X\. Please remove\. Indices: \[0\]$")
+
+
+if __name__ == '__main__':
+    test_issue1()


### PR DESCRIPTION
When there are zero variance features `corals` throws vague error messages. This has been fixed and a more descriptive error is raised. Alternatively, zero variance indices can be returned. 

This has been raised as a side note in: #1